### PR TITLE
Fix root URL routing for home page

### DIFF
--- a/sitehub/urls.py
+++ b/sitehub/urls.py
@@ -3,6 +3,8 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('app/', include('accounts.urls')),
-    path('app/', include('bids.urls')),
+    # Route the root path to the accounts app so visiting ``/`` works
+    path('', include('accounts.urls')),
+    # Expose bid-related URLs under ``/bids/`` instead of a generic ``/app/``
+    path('bids/', include('bids.urls')),
 ]


### PR DESCRIPTION
## Summary
- Route the root path to the accounts dashboard
- Move bid URLs under a specific `/bids/` prefix

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68aba3c11734832a959fd61b66faea32