### PR TITLE
Fix manage path for Render deployment

### DIFF
--- a/copart_clone/__init__.py
+++ b/copart_clone/__init__.py
@@ -1,0 +1,14 @@
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+DJANGO_APP = BASE_DIR / 'django_app'
+COPART_CLONE_DIR = DJANGO_APP / 'copart_clone'
+
+# Ensure Django app path is available for imports like `sitehub`
+if str(DJANGO_APP) not in sys.path:
+    sys.path.insert(0, str(DJANGO_APP))
+
+# Point this package to the real copart_clone package inside django_app
+__path__ = [str(COPART_CLONE_DIR)]

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import os
+import sys
+from pathlib import Path
+
+# Ensure the Django app directory is on the Python path
+BASE_DIR = Path(__file__).resolve().parent
+DJANGO_APP = BASE_DIR / 'django_app'
+if str(DJANGO_APP) not in sys.path:
+    sys.path.insert(0, str(DJANGO_APP))
+
+if __name__ == '__main__':
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'sitehub.settings')
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)


### PR DESCRIPTION
## Summary
- Add top-level manage.py that inserts `django_app` into PYTHONPATH
- Map root `copart_clone` package to Django project to support `gunicorn copart_clone.wsgi`

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68acdaf07ebc832aaf713cd07ed7f473