### PR TITLE
Fix base URL rewriting for Copart mirror

### DIFF
--- a/proxy/nginx/default.conf.template
+++ b/proxy/nginx/default.conf.template
@@ -19,8 +19,8 @@ server {
     gunzip on;
     sub_filter_once off;            # aplica em todo HTML da resposta
     sub_filter_types text/html;
-    sub_filter 'https://www.copart.com.br' '';
-    sub_filter 'https://copart.com.br' '';
+    sub_filter 'https://www.copart.com.br' '/';
+    sub_filter 'https://copart.com.br' '/';
     sub_filter '//www.copart.com.br' '/';
     sub_filter '</body>' '<a href="${WHATSAPP_URL}" id="zap-fab" target="_blank" rel="noopener" style="position:fixed;right:18px;bottom:18px;z-index:2147483647;display:inline-flex;align-items:center;gap:8px;padding:12px 14px;background:#25D366;color:#fff;border-radius:999px;text-decoration:none;box-shadow:0 6px 20px rgba(0,0,0,0.2);font-family:system-ui,sans-serif;font-size:14px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="20" height="20" aria-hidden="true"><path fill="currentColor" d="M19.11 17.29c-.27-.13-1.6-.79-1.85-.88-.25-.09-.43-.13-.61.14-.18.27-.7.88-.86 1.06-.16.18-.32.2-.59.07-.27-.13-1.12-.41-2.14-1.31-.79-.7-1.32-1.56-1.48-1.82-.16-.27-.02-.41.11-.54.11-.11.25-.29.38-.43.13-.14.16-.25.25-.43.09-.18.05-.34-.02-.48-.07-.13-.61-1.46-.84-2-.22-.53-.45-.46-.61-.46-.16 0-.34-.02-.52-.02s-.48.07-.73.34c-.25.27-.95.93-.95 2.27s.98 2.64 1.12 2.82c.14.18 1.93 2.95 4.68 4.13.65.28 1.16.45 1.56.57.65.21 1.24.18 1.71.11.52-.08 1.6-.65 1.83-1.28.23-.63.23-1.17.16-1.28-.07-.11-.25-.18-.52-.31z"/><path fill="currentColor" d="M16 3C9.383 3 4 8.383 4 15c0 2.114.549 4.101 1.507 5.828L4 29l8.317-1.459C13.967 27.827 14.965 28 16 28c6.617 0 12-5.383 12-12S22.617 3 16 3zm0 22.5c-1.04 0-2.04-.188-2.965-.533l-.212-.08-4.923.863.86-4.766-.097-.167A9.47 9.47 0 0 1 6.5 15c0-5.238 4.262-9.5 9.5-9.5s9.5 4.262 9.5 9.5-4.262 9.5-9.5 9.5z"/></svg><span style="margin-left:6px">Fale no WhatsApp</span></a></body>';
 


### PR DESCRIPTION
## Summary
- ensure Nginx sub_filter replaces Copart links with root path instead of empty string

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68ace7cdd674832a869f858623266878