### PR TITLE
Set default Django upstream for proxy to fix mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ copart_full_mirror_project/
    - Serviço **Django**: apontar para `django_app/` (env Docker).
    - Serviço **Proxy**: apontar para `proxy/` (env Docker).
 3. Após o deploy do Django, copie a **URL pública** do Django (ex.: `https://sua-app.onrender.com`).
-4. Nas **variáveis do Proxy**, defina `DJANGO_UPSTREAM` com a URL pública do Django.
+4. Nas **variáveis do Proxy**, defina `DJANGO_UPSTREAM` com a URL pública do Django
+   (padrão local: `localhost:8000`).
 5. Adicione seu domínio customizado ao **Proxy** (esse será o front principal).
 6. Acesse `seu-dominio/admin` para entrar no **Django Admin** (credenciais configuradas via env).
 
@@ -56,6 +57,7 @@ copart_full_mirror_project/
   - `UPSTREAM_HOST=www.copart.com.br`
   - `WHATSAPP_URL=http://wa.me/5511958462009`
   - `DJANGO_UPSTREAM` = URL do serviço Django (ex.: `https://sua-app.onrender.com`)
+    - padrão local: `localhost:8000`
 - **Django**:
   - `PORT` (Render define automaticamente)
   - `DJANGO_SECRET_KEY` (defina um valor seguro)

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -7,7 +7,7 @@ COPY nginx/default.conf.template /etc/nginx/templates/default.conf.template
 ENV PORT=8080 \
     UPSTREAM_HOST=www.copart.com.br \
     WHATSAPP_URL=http://wa.me/5511958462009 \
-    DJANGO_UPSTREAM=
+    DJANGO_UPSTREAM=localhost:8000
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
- Default DJANGO_UPSTREAM to localhost:8000 so the proxy mirrors www.copart.com.br even when the variable is unset
- Document the new default in README

## Testing
- ⚠️ `docker build proxy -t proxy-test` (command not found: docker)

------
https://chatgpt.com/codex/tasks/task_e_68acee3a866c832a90013939f9b44223