### PR TITLE
Refactor auth templates to use base layout

### DIFF
--- a/django_app/templates/accounts/login.html
+++ b/django_app/templates/accounts/login.html
@@ -1,29 +1,15 @@
-<!doctype html>
-<html lang="pt-BR">
-<head>
-  <meta charset="utf-8">
-  <title>Entrar - Copart Brasil</title>
-  <style>
-    body {font-family: Arial, sans-serif; background:#f5f5f5; margin:0;}
-    .auth-container {max-width:360px; margin:60px auto; padding:20px; background:#fff;
-                     border:1px solid #ddd; box-shadow:0 2px 4px rgba(0,0,0,0.1);} 
-    h2 {color:#003f7d; text-align:center; margin-bottom:24px;}
-    .auth-container form p {margin:12px 0;}
-    button {width:100%; background:#003f7d; color:#fff; padding:10px; border:none; cursor:pointer;}
-    button:hover {background:#002a5c;}
-    .auth-alt {text-align:center; margin-top:16px;}
-  </style>
-</head>
-<body>
+{% extends "base.html" %}
+{% block title %}Entrar{% endblock %}
+{% block content %}
 <div class="auth-container">
   <h2>Entrar</h2>
-  <form method="post">{% csrf_token %}
+  <form method="post">
+    {% csrf_token %}
     {{ form.as_p }}
     <button type="submit">Entrar</button>
   </form>
   <div class="auth-alt">
-    <p>Não tem conta? <a href="/register/">Registrar</a></p>
+    <p>Não tem conta? <a href="{% url 'register' %}">Registrar</a></p>
   </div>
 </div>
-</body>
-</html>
+{% endblock %}

--- a/django_app/templates/accounts/register.html
+++ b/django_app/templates/accounts/register.html
@@ -1,29 +1,15 @@
-<!doctype html>
-<html lang="pt-BR">
-<head>
-  <meta charset="utf-8">
-  <title>Registrar - Copart Brasil</title>
-  <style>
-    body {font-family: Arial, sans-serif; background:#f5f5f5; margin:0;}
-    .auth-container {max-width:360px; margin:60px auto; padding:20px; background:#fff;
-                     border:1px solid #ddd; box-shadow:0 2px 4px rgba(0,0,0,0.1);} 
-    h2 {color:#003f7d; text-align:center; margin-bottom:24px;}
-    .auth-container form p {margin:12px 0;}
-    button {width:100%; background:#003f7d; color:#fff; padding:10px; border:none; cursor:pointer;}
-    button:hover {background:#002a5c;}
-    .auth-alt {text-align:center; margin-top:16px;}
-  </style>
-</head>
-<body>
+{% extends "base.html" %}
+{% block title %}Criar conta{% endblock %}
+{% block content %}
 <div class="auth-container">
   <h2>Criar conta</h2>
-  <form method="post">{% csrf_token %}
+  <form method="post">
+    {% csrf_token %}
     {{ form.as_p }}
     <button type="submit">Criar conta</button>
   </form>
   <div class="auth-alt">
-    <p>Já tem conta? <a href="/login/">Entrar</a></p>
+    <p>Já possui conta? <a href="{% url 'login' %}">Entrar</a></p>
   </div>
 </div>
-</body>
-</html>
+{% endblock %}

--- a/django_app/templates/base.html
+++ b/django_app/templates/base.html
@@ -1,0 +1,21 @@
+{% load static %}
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}Copart Brasil{% endblock %}</title>
+  <style>
+    body {font-family: Arial, sans-serif; background:#f5f5f5; margin:0;}
+    .auth-container {max-width:360px; margin:60px auto; padding:20px; background:#fff;
+                     border:1px solid #ddd; box-shadow:0 2px 4px rgba(0,0,0,0.1);}
+    h2 {color:#003f7d; text-align:center; margin-bottom:24px;}
+    .auth-container form p {margin:12px 0;}
+    button {width:100%; background:#003f7d; color:#fff; padding:10px; border:none; cursor:pointer;}
+    button:hover {background:#002a5c;}
+    .auth-alt {text-align:center; margin-top:16px;}
+  </style>
+</head>
+<body>
+  {% block content %}{% endblock %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add base template for auth pages
- simplify register and login templates by extending base and using url tags

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68acf4168110832ab7a33f3c9594ca2d