### PR TITLE
fix routing so proxy handles root

### DIFF
--- a/django_app/sitehub/urls.py
+++ b/django_app/sitehub/urls.py
@@ -3,8 +3,8 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    # Route the root path to the accounts app so visiting ``/`` works
-    path('', include('accounts.urls')),
+    # Serve account pages under ``/app/`` leaving ``/`` for the Copart mirror
+    path('app/', include('accounts.urls')),
     # Expose bid-related URLs under ``/bids/`` instead of a generic ``/app/``
     path('bids/', include('bids.urls')),
 ]


### PR DESCRIPTION
## Summary
- serve account pages under `/app/` so the proxy can mirror Copart at `/`

## Testing
- `python manage.py test`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68ae4828ead0832aa2cbb889916c3c86